### PR TITLE
フリー塗装お試し

### DIFF
--- a/paintWall/image.html
+++ b/paintWall/image.html
@@ -15,6 +15,9 @@
     <h2>画像内をクリックしてください</h2>
     <canvas id="canvas"></canvas>
     <h2>実行結果</h2>
+    <input type="button" id="paint" value="塗装">
+    <input type="button" id="delete" value="削除">
+    <span id="modeChange"></span>
     <canvas id="canvasFinal"></canvas>
     <br>
     <h2>canvasGray</h2>

--- a/paintWall/script.js
+++ b/paintWall/script.js
@@ -189,6 +189,7 @@ cv.onRuntimeInitialized = () => {
       showImage("canvasDilatedRgb", dilatedRgb);
       // メモリ解放
       floodedImage.delete();
+      M.delete();
 
       // HSVのマージ
       const rgbHsvImage = new cv.Mat();


### PR DESCRIPTION
再塗装処理追加

* 再塗装モード
  * canvasMergedを取得後に同じ色で線を引いた後、元画像とマージする
  * opencvで線を引く処理がないので、jsの処理で再現している
* 消しゴムモード
  * 同じサイズでマスク画像を用意して結合する
    * 同じサイズの真っ黒な画像を用意
    * 白で線を引いてマスク画像とする
    * マスク画像と元画像で結合
      * フリーで線を引かれたマスク画像でマスクされた「元画像」ができる
    * 「マスクされた元画像」と「canvasMerged(塗装後の画像)」で論理和を取得
      *  マスクされた元画像で上書きされた「塗装後の画像」ができる
    * 論理和取得後の画像と元画像を結合させる 